### PR TITLE
fix: update API route params for Next 15

### DIFF
--- a/src/app/api/product/[id]/getProductById/route.ts
+++ b/src/app/api/product/[id]/getProductById/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Product } from "@/models/Products";
 import { connectDB } from "@/lib/dbconnect";
-import type { NextApiRequest } from "next";
 
 export async function GET(
   req: NextRequest,
-  context: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await connectDB();
-    const { id } = context.params;
+    const { id } = await params;
 
     if (!id) {
       return NextResponse.json({ message: "Product ID is required" }, { status: 400 });

--- a/src/app/api/product/[id]/likeProductById/route.ts
+++ b/src/app/api/product/[id]/likeProductById/route.ts
@@ -4,11 +4,11 @@ import { Product } from "@/models/Products";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { userId } = await req.json();
-    const { id: productId } = params;
+    const { id: productId } = await params;
 
     if (!userId) {
       return NextResponse.json({ message: "User ID is required" }, { status: 400 });

--- a/src/app/api/product/[id]/route.ts
+++ b/src/app/api/product/[id]/route.ts
@@ -4,20 +4,20 @@ import { connectDB } from "@/lib/dbconnect";
 import type { ApiResponse, Product as IProduct } from "@/types";
 
 interface RouteContext {
-	params: {
-		id: string;
-	};
+        params: Promise<{
+                id: string;
+        }>;
 }
 
 // GET - Fetch single product by ID
 export async function GET(
-	request: NextRequest,
-	context: RouteContext
+        request: NextRequest,
+        context: RouteContext
 ): Promise<NextResponse<ApiResponse<IProduct>>> {
-	try {
-		await connectDB();
+        try {
+                await connectDB();
 
-		const { id } = context.params;
+                const { id } = await context.params;
 
 		if (!id) {
 			return NextResponse.json(

--- a/src/app/api/product/[id]/updateProduct/route.ts
+++ b/src/app/api/product/[id]/updateProduct/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { Product } from "@/models/Products";
 
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
 
 
-  const productId = params.id;
+  const { id: productId } = await params;
   const body = await req.json();
 
   try {


### PR DESCRIPTION
## Summary
- update product routes to await params for Next.js 15

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unused vars and no-explicit-any errors)*
- `npm run build` *(fails: unable to fetch PT Mono font)*

------
https://chatgpt.com/codex/tasks/task_e_6890d59f6140832e9a4663f6f90a0917